### PR TITLE
Adding junit (java) runner; Modified runner model to be more flexible to...

### DIFF
--- a/apps/TeamTest/models/runner.php
+++ b/apps/TeamTest/models/runner.php
@@ -53,7 +53,14 @@ class runner{
         }
         $runner = $this->getRunner(pathinfo($file));
         if($runner){
-            $results['cmd'] = $runner['test']['cmd'] . ' "' . $file . '" 2>&1';
+            $testFileInfo = array(
+                '%FullTestPath%' => $file,
+                '%TestDir%' => pathinfo($file, PATHINFO_DIRNAME),
+                '%TestBaseName%' => pathinfo($file, PATHINFO_BASENAME),
+                '%TestFileName%' => pathinfo($file, PATHINFO_FILENAME),
+                '%TestFileExt%' => pathinfo($file, PATHINFO_EXTENSION)
+            );
+            $results['cmd'] = str_replace(array_keys($testFileInfo), array_values($testFileInfo), $runner['test']['cmd']);
             $results['raw'] = $this->execute($results['cmd']);
             /** The results? **/
             $results['status'] = $this->match($runner['test']['pass'], $results['raw'], 'pass', $results['status']);

--- a/apps/TeamTest/runners/java.json
+++ b/apps/TeamTest/runners/java.json
@@ -1,0 +1,9 @@
+{
+    "filetypes":["java"],
+    "scratch": "java",
+    "test": {
+        "cmd":"cd \"%TestDir%\" && javac \"%TestBaseName%\" 2>&1 && java org.junit.runner.JUnitCore \"%TestFileName%\" 2>&1",
+        "pass":"(OK)",
+        "fail": "[(FAILED)( cannot )]"
+    }
+}

--- a/apps/TeamTest/runners/javascript.json
+++ b/apps/TeamTest/runners/javascript.json
@@ -2,7 +2,7 @@
     "filetypes":["js","html"],
     "scratch": "phantomjs",
     "test": {
-        "cmd":"phantomjs js/tt/run-jasmine.js",
+        "cmd":"phantomjs js/tt/run-jasmine.js \"%FullTestPath%\"",
         "pass":"(Passing)(\\s+)(\\d+)(\\s+)(spec)",
         "fail": "(test)(\\(s\\))(\\s+)(FAILED)(:)"
     }

--- a/apps/TeamTest/runners/php.json
+++ b/apps/TeamTest/runners/php.json
@@ -2,7 +2,7 @@
     "filetypes":["php"],
     "scratch": "php",
     "test": {
-        "cmd":"phpunit",
+        "cmd":"phpunit \"%FullTestPath%\"",
         "pass":"(OK)(\\s+)(\\()",
         "fail": "(FAILURES)(!)"
     }

--- a/apps/TeamTest/runners/python.json
+++ b/apps/TeamTest/runners/python.json
@@ -2,7 +2,7 @@
     "filetypes":["py"],
     "scratch": "python",
     "test": {
-        "cmd":"python",
+        "cmd":"python \"%FullTestPath%\" 2>&1",
         "pass":"(OK)",
         "fail": "(FAILED)(\\s+)(\\()(failures)"
     }


### PR DESCRIPTION
... more cmds

To run java tests, the following must be set in your env (usually through .bashrc):

export PATH=$PATH:/System/Library/Java/JavaVirtualMachines/1.6.0.jdk/bin:
export CLASSPATH=$CLASSPATH:/usr/share/java/junit.jar
