### PR TITLE
Better support for Java tests

### DIFF
--- a/apps/teamtest/models/files.php
+++ b/apps/teamtest/models/files.php
@@ -14,8 +14,9 @@ class files{
             if($callback($fileinfo, $params)){
                 $ignored = false;
                 foreach($global_ignore as $ignore){
-                    if(stristr($fileinfo->getPathname(), $ignore)){
+                    if(stristr($fileinfo->getPathname(), $ignore) !== false){
                         $ignored = true;
+                        break; // This file is ignored, no need to keep checking
                     }
                 }
                 if(!$ignored){

--- a/apps/teamtest/models/project.php
+++ b/apps/teamtest/models/project.php
@@ -41,7 +41,7 @@ class project{
         $project = array(
             'basepath'=>$basepath,
             'name'=>$name,
-            'ignored_files'=>array('.git','._','.idea'),
+            'ignored_files'=>array('.git','._','.idea','.class'),
             'shortname'=>$this->filename($name)
         );
         $this->projects[$project['name']] = $project;

--- a/apps/teamtest/models/runner.php
+++ b/apps/teamtest/models/runner.php
@@ -60,12 +60,15 @@ class runner{
         $runner = $this->getRunner(pathinfo($file));
         if($runner){
             $testFileInfo = array(
-                '%FullTestPath%' => $file,
-                '%TestDir%' => pathinfo($file, PATHINFO_DIRNAME),
-                '%TestBaseName%' => pathinfo($file, PATHINFO_BASENAME),
-                '%TestFileName%' => pathinfo($file, PATHINFO_FILENAME),
-                '%TestFileExt%' => pathinfo($file, PATHINFO_EXTENSION)
+                '%FullTestPath%' => $file, // Ex: /path/to/fileTest.xyz
+                '%TestDir%' => pathinfo($file, PATHINFO_DIRNAME), // Ex: /path/to
+                '%TestBaseName%' => pathinfo($file, PATHINFO_BASENAME), // Ex: fileTest.xyz
+                '%TestFileName%' => pathinfo($file, PATHINFO_FILENAME), // Ex: fileTest
+                '%TestFileExt%' => pathinfo($file, PATHINFO_EXTENSION) // Ex: xyz
             );
+            if ($testFileInfo['%TestFileExt%'] === 'java'){
+                $this->javaFileInfo($testFileInfo); //Adds java info about test file to $testFileInfo
+            }
             $results['cmd'] = str_replace(array_keys($testFileInfo), array_values($testFileInfo), $runner['test']['cmd']);
             $results['raw'] = $this->execute($results['cmd']);
             /** The results? **/
@@ -80,5 +83,49 @@ class runner{
             }
         }
         return $results;
+    }
+
+    function javaFileInfo(&$testFileInfo) {
+        $testFileInfo['%JavaPackage%'] = $this->javaPackageFromFile($testFileInfo['%FullTestPath%']);
+        $testFileInfo['%JavaClass%'] = $this->javaClassFromFile($testFileInfo['%FullTestPath%'], $testFileInfo['%JavaPackage%']);
+        $testFileInfo['%JavaSrcPath%'] = $this->javaSrcPathFromPkg($testFileInfo['%TestDir%'], $testFileInfo['%JavaPackage%']);
+    }
+
+    private function javaPackageFromFile($javaFilePath) {
+        $packages = array();
+        exec('grep "package " "'.$javaFilePath.'"', $packages);
+        foreach($packages as $pkg) {
+            $split = explode(' ', $pkg);
+            if (count($split) == 2) { // package *;
+                return trim($split[1], ';');
+            }
+        }
+        return '';
+    }
+
+    private function javaClassFromFile($javaFilePath, $javaPackage) {
+        $classes = array();
+        exec ('grep "public class " "'.$javaFilePath.'"', $classes);
+        foreach($classes as $class) {
+            $split = explode(' ', $class);
+            if (count($split) >= 3 ) { // public class * [{]
+                if ($javaPackage) {
+                    return $javaPackage . '.' . $split[2];
+                } else {
+                    return $split[2];
+                }
+            }
+        }
+    }
+
+    private function javaSrcPathFromPkg($javaFileDir, $javaPackage) {
+        $pkg_path = str_replace('.', '/', $javaPackage);
+        $guess_path = $this->str_lreplace($pkg_path,'',$javaFileDir);
+        return realpath($guess_path);
+    }
+
+    private function str_lreplace($search, $replace, $subject)
+    {
+        return preg_replace('~(.*)' . preg_quote($search, '~') . '(.*?)~', '$1' . $replace . '$2', $subject, 1);
     }
 }

--- a/apps/teamtest/routes.php
+++ b/apps/teamtest/routes.php
@@ -28,10 +28,24 @@ $app->delete('/project/test/{project}/{test}', function($project, $test, Request
 });
 
 $app->get('/files/modified/{query}/{project}', function($query, $project) use($app){
-    $files = $app['files']->query($app['project']->config('basepath', $project, __DIR__), $query, function($fileinfo, $query){
-        return $fileinfo->getMTime() >= $query && !$fileinfo->isDir();
-    },$app['project']->config('ignored_files', $project, array()), 1);
-    return $app->json(array('time'=>time(),'query'=>$query, 'files'=>$files, 'basepath'=>$app['project']->config('basepath', $project, __DIR__),'modified'=>count($files) ? true : false), 200);
+    $files = $app['files']->query(
+        $app['project']->config(
+            'basepath',
+            $project,
+            __DIR__
+        ),
+        $query,
+        function($fileinfo, $query){
+            return $fileinfo->getMTime() >= $query && !$fileinfo->isDir();
+        },
+        $app['project']->config(
+            'ignored_files',
+            $project,
+            array()
+        ),
+        1
+    );
+    return $app->json(array('time'=>time(),'query'=>$query, 'files'=>$files, 'basepath'=>$app['project']->config('basepath', $project, __DIR__),'modified'=>count($files) ? true : false, 'ignored'=> $app['project']->config('ignored_files',$project, array()) ), 200);
 });
 
 $app->post('test', function(Request $request) use ($app){
@@ -41,8 +55,21 @@ $app->post('test', function(Request $request) use ($app){
 });
 
 $app->get('/files/{query}/{project}', function($query, $project) use($app){
-    $files = $app['files']->query($app['project']->config('basepath', $project, __DIR__), $query, function($fileinfo, $query){
-        return stristr($fileinfo, $query) && !$fileinfo->isDir();
-    });
+    $files = $app['files']->query(
+        $app['project']->config(
+            'basepath',
+            $project,
+            __DIR__
+        ),
+        $query,
+        function($fileinfo, $query){
+            return stristr($fileinfo, $query) && !$fileinfo->isDir();
+        },
+        $app['project']->config(
+            'ignored_files',
+            $project,
+            array()
+        )
+    );
     return $app->json(is_array($files) ? $files : array(), is_array($files) ? 200 : 404);
 });

--- a/apps/teamtest/runners/java.json
+++ b/apps/teamtest/runners/java.json
@@ -2,7 +2,7 @@
     "filetypes":["java"],
     "scratch": "java",
     "test": {
-        "cmd":"cd \"%TestDir%\" && javac \"%TestBaseName%\" 2>&1 && java org.junit.runner.JUnitCore \"%TestFileName%\" 2>&1",
+        "cmd":"cd \"%TestDir%\" && javac -sourcepath \"%JavaSrcPath%\" -classpath \"/usr/share/java/junit.jar:%JavaSrcPath%\" \"%FullTestPath%\" 2>&1 && java -cp \"/usr/share/java/junit.jar:%JavaSrcPath%\" org.junit.runner.JUnitCore \"%JavaClass%\" 2>&1",
         "pass":"(OK)",
         "fail": "[(FAILED)( cannot )]"
     }

--- a/apps/teamtest/tests/teamtest/models/projectTest.php
+++ b/apps/teamtest/tests/teamtest/models/projectTest.php
@@ -25,7 +25,7 @@ class projectTest extends PHPUnit_Framework_TestCase {
         /* do some quick assertions to make sure the creation is succesful */
         $this->assertEquals('/home/cmerrill/something/', $this->projects->config('basepath', 'kcwazheretest'));
         $this->assertEquals('kcwazheretest', $this->projects->config('name', 'kcwazheretest'));
-        $this->assertEquals(array('.git','._','.idea'), $this->projects->config('ignored_files', 'kcwazheretest'));
+        $this->assertEquals(array('.git','._','.idea','.class'), $this->projects->config('ignored_files', 'kcwazheretest'));
 
         /* go ahead and remove the test now */
         $this->projects->remove('kcwazheretest');

--- a/www/js/tt/app.js
+++ b/www/js/tt/app.js
@@ -226,8 +226,12 @@ function filesCtrl($scope, $http, states, projects) {
                 $scope.states.file_text = "Your basepath cannot be found, please update " + $scope.projects.selected.shortname;
             })
             .success(function (data) {
-                $scope.files = data;
-                $scope.states.file_text = _.size(data) + ' files matched "' + $scope.query + '"';
+                if (Array.isArray(data)) {
+                    $scope.files = data;
+                    $scope.states.file_text = _.size(data) + ' files matched "' + $scope.query + '"';
+                } else {
+                    $scope.states.file_text = "There was a problem collecting the list of files. Is the server running?";
+                }
             });
     }
 


### PR DESCRIPTION
Improved support for java tests (tests can now be in packages).
The java tester assumes that junit.jar is located at /usr/share/java/junit.jar
If your junit.jar is located elsewhere, modify apps/teamtest/runners/java.json.

Also, this commit adds some error checking to the file list when adding tests.

To better support java tests, *.class files are now in the list of global_ignored files on new projects (Java tests will try to rerun forever with old project.json files.)
